### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/django-tests.yml
+++ b/.github/workflows/django-tests.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/hoomn/project-management-backend/security/code-scanning/1](https://github.com/hoomn/project-management-backend/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Since the workflow only requires read access to repository contents, the permissions should be set to `contents: read`. This change ensures that the workflow operates with the minimum necessary privileges.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
